### PR TITLE
Changing button type to avoid auto-submitting forms

### DIFF
--- a/js/bootstrap-colorpalette.js
+++ b/js/bootstrap-colorpalette.js
@@ -23,7 +23,7 @@
     $.each(_aaColor, function(i, aColor){
       aHTML.push('<div>');
       $.each(aColor, function(i, sColor) {
-        var sButton = ['<button class="btn-color" style="background-color:', sColor,
+        var sButton = ['<button type="button" class="btn-color" style="background-color:', sColor,
           '" data-value="', sColor,
           '" title="', sColor,
           '"></button>'].join('');


### PR DESCRIPTION
When colorpicker is inside form, clicking any button will auto-submit parent form. Adding type="button" will prevent this action. More on SO: http://stackoverflow.com/questions/9824808/disable-form-auto-submit-on-button-click
