### PR TITLE
Added line to prevent auto submission of form

### DIFF
--- a/js/bootstrap-colorpalette.js
+++ b/js/bootstrap-colorpalette.js
@@ -36,6 +36,7 @@
 
   var attachEvent = function(palette) {
     palette.element.on('click', function(e) {
+      e.preventDefault();
       var welTarget = $(e.target),
           welBtn = welTarget.closest('.btn-color');
 


### PR DESCRIPTION
When color palette is placed inside a form, selecting a color submits the form. To fix this issue its necessary to add e.preventDefault();
